### PR TITLE
fix(mongodb): make MongoDB username and password optional

### DIFF
--- a/crates/mongodb/src/config.rs
+++ b/crates/mongodb/src/config.rs
@@ -27,12 +27,12 @@ impl Config {
         ConfigBuilder::default()
     }
 
-    pub fn username(&self) -> &str {
-        self.username.as_deref().unwrap()
+    pub fn username(&self) -> Option<&str> {
+        self.username.as_deref()
     }
 
-    pub fn password(&self) -> &str {
-        self.password.as_deref().unwrap()
+    pub fn password(&self) -> Option<&str> {
+        self.password.as_deref()
     }
 
     pub fn address(&self) -> &str {


### PR DESCRIPTION
The two values are now provided as `Option` as they are defined in the config struct already.

The setup now only created users if both, username and password, have been provided

Closes: #78