### PR TITLE
Add function to fetch child groups by parent group ID in Keycloak

### DIFF
--- a/crates/keycloak/src/client.rs
+++ b/crates/keycloak/src/client.rs
@@ -398,6 +398,31 @@ impl Keycloak {
             })
     }
 
+    pub async fn group_by_id_with_children(
+        &self,
+        realm: &str,
+        group_id: &str,
+    ) -> Result<Vec<GroupRepresentation>, KeycloakError> {
+        let subgroups = self.inner
+            .admin
+            .realm_groups_with_group_id_children_get(
+                realm,
+                group_id,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await?;
+
+        Ok(subgroups
+            .into_iter()
+            .filter(|g| g.id.is_some())
+            .map(From::from)
+            .collect())
+    }
+
     pub async fn role_members(
         &self,
         realm: &str,


### PR DESCRIPTION
Added function to fetch child groups by parent group ID to improve group hierarchy retrieval as group_by_path doesnt include the children