### PR TITLE
Expose `client_id` in `send_verify_email_user`

### DIFF
--- a/crates/keycloak/src/client.rs
+++ b/crates/keycloak/src/client.rs
@@ -940,6 +940,7 @@ impl Keycloak {
         &self,
         realm: &str,
         user_id: &str,
+        client_id: Option<String>,
         redirect_url: Option<String>,
     ) -> Result<(), KeycloakError> {
         self.inner
@@ -947,7 +948,7 @@ impl Keycloak {
             .realm_users_with_user_id_send_verify_email_put(
                 realm,
                 user_id,
-                None,
+                client_id,
                 None,
                 redirect_url,
             )


### PR DESCRIPTION
We need to expose client_id in send_verify_email_user, because Keycloak seems to not accept a redirect_url without a client_id. Without the client_id it returns a Client id missing error.

It also allows to set the `client_id` without a `redirect_url`, which enables Keycloakify to correctly show a `Back to application` link after a user updated their profile.

Closes #119 