### PR TITLE
Document qm-nats crate (issue #96)

### DIFF
--- a/crates/nats/src/lib.rs
+++ b/crates/nats/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 //! NATS JetStream integration for building distributed microservices.
 //!
 //! This crate provides utilities for connecting to NATS with JetStream support,
@@ -76,6 +78,7 @@ use tokio::task::JoinHandle;
 
 pub use async_nats;
 
+/// Subject module for event subject path generation.
 pub mod subject;
 
 /// Configuration for NATS JetStream connection.
@@ -95,43 +98,56 @@ pub struct Config {
 }
 
 impl Config {
+    /// Creates a new Config from environment variables with default NATS_ prefix.
     pub fn new() -> envy::Result<Self> {
         ConfigBuilder::default().build()
     }
 
+    /// Creates a new ConfigBuilder for custom configuration.
     pub fn builder<'a>() -> ConfigBuilder<'a> {
         ConfigBuilder::default()
     }
 
+    /// Returns the NATS server address.
     pub fn address(&self) -> &str {
         self.address.as_deref().unwrap()
     }
 
+    /// Returns the NATS server port.
     pub fn port(&self) -> u16 {
         self.port.unwrap_or(3000)
     }
+
+    /// Returns the key-value bucket name for system locks.
     pub fn sys_locks(&self) -> &str {
         self.sys_locks.as_deref().unwrap_or("SYS_LOCKS")
     }
+
+    /// Returns the JetStream stream name for events.
     pub fn events_stream_name(&self) -> &str {
         self.events_stream_name.as_deref().unwrap_or("EVENTS")
     }
+
+    /// Returns the subject pattern for events stream.
     pub fn events_stream_subject(&self) -> &str {
         self.events_stream_subject.as_deref().unwrap_or("ev.>")
     }
 }
 
+/// Builder for creating Config with custom settings.
 #[derive(Default)]
 pub struct ConfigBuilder<'a> {
     prefix: Option<&'a str>,
 }
 
 impl<'a> ConfigBuilder<'a> {
+    /// Sets a custom environment variable prefix.
     pub fn with_prefix(mut self, prefix: &'a str) -> Self {
         self.prefix = Some(prefix);
         self
     }
 
+    /// Builds the Config from environment variables.
     pub fn build(self) -> envy::Result<Config> {
         let prefix = self.prefix.unwrap_or("NATS_");
         let mut cfg: Config = envy::prefixed(prefix).from_env()?;
@@ -145,6 +161,7 @@ impl<'a> ConfigBuilder<'a> {
     }
 }
 
+/// Internal state for the Nats client.
 pub struct Inner {
     client: Client,
     config: Config,
@@ -160,6 +177,7 @@ pub struct Nats {
 }
 
 impl Nats {
+    /// Creates a new Nats client and connects to the NATS server.
     pub async fn new(config: Config) -> Result<Self, ConnectError> {
         let client = async_nats::ConnectOptions::new()
             .max_reconnects(Some(1))
@@ -170,14 +188,17 @@ impl Nats {
         })
     }
 
+    /// Returns a reference to the underlying NATS client.
     pub fn client(&self) -> &Client {
         &self.inner.client
     }
 
+    /// Returns a reference to the configuration.
     pub fn config(&self) -> &Config {
         &self.inner.config
     }
 
+    /// Creates a new event publisher.
     pub async fn publisher(&self) -> Result<Publisher, CreateStreamError> {
         let ctx = jetstream::new(self.inner.client.clone());
         let p = Publisher { ctx };
@@ -185,6 +206,7 @@ impl Nats {
         Ok(p)
     }
 
+    /// Creates a durable pull consumer with the given name.
     pub async fn sys_consumer(&self, name: String) -> Result<PullConsumer, ConsumerError> {
         let ctx = jetstream::new(self.inner.client.clone());
         ctx.create_consumer_on_stream(
@@ -197,6 +219,7 @@ impl Nats {
         .await
     }
 
+    /// Creates a durable pull consumer with a filter subject.
     pub async fn sys_consumer_with_filter(
         &self,
         name: String,
@@ -214,6 +237,7 @@ impl Nats {
         .await
     }
 
+    /// Creates a durable pull consumer with multiple filter subjects.
     pub async fn sys_consumer_with_filters(
         &self,
         name: String,
@@ -231,6 +255,7 @@ impl Nats {
         .await
     }
 
+    /// Creates a temporary pull consumer with a filter subject.
     pub async fn tmp_sys_consumer_with_filter(
         &self,
         filter_subject: String,
@@ -247,11 +272,13 @@ impl Nats {
         .await
     }
 
+    /// Creates a distributed locks manager.
     pub async fn distributed_locks(&self) -> Result<DistributedLocks, DistributedLocksError> {
         let ctx = jetstream::new(self.inner.client.clone());
         DistributedLocks::new(ctx, &self.inner.config).await
     }
 
+    /// Creates a sequence manager.
     pub fn sequence_manager(&self) -> SequenceManager {
         let ctx = jetstream::new(self.inner.client.clone());
         SequenceManager { ctx }
@@ -263,6 +290,7 @@ impl Nats {
 /// Implement this trait on your event types to enable automatic
 /// subject path generation for event publishing.
 pub trait EventToSubject<M> {
+    /// Converts the event to a NATS subject.
     fn event_to_subject(&self) -> async_nats::Subject;
 }
 
@@ -292,6 +320,7 @@ impl Publisher {
         Ok(())
     }
 
+    /// Publishes an event to the given subject.
     pub async fn publish<S: ToSubject, P: ?Sized + serde::Serialize>(
         &self,
         subject: S,
@@ -303,6 +332,7 @@ impl Publisher {
         Ok(())
     }
 
+    /// Publishes an event using the subject derived from the event type.
     pub async fn publish_event<S, M, P>(&self, subject: &S, payload: &P) -> anyhow::Result<()>
     where
         S: ?Sized + EventToSubject<M>,
@@ -327,10 +357,13 @@ impl AsRef<Context> for Publisher {
 /// Error type for distributed lock operations.
 #[derive(thiserror::Error, Debug)]
 pub enum DistributedLocksError {
+    /// Error connecting to NATS.
     #[error(transparent)]
     Connect(#[from] async_nats::error::Error<ConnectErrorKind>),
+    /// Error creating a key-value store.
     #[error(transparent)]
     CreateKeyValue(#[from] async_nats::error::Error<CreateKeyValueErrorKind>),
+    /// Error accessing a key-value store.
     #[error(transparent)]
     KeyValue(#[from] async_nats::error::Error<KeyValueErrorKind>),
 }
@@ -391,6 +424,7 @@ impl DistributedLocks {
         Ok(true)
     }
 
+    /// Returns a lock manager for system locks.
     pub async fn sys_locks(&self) -> anyhow::Result<LockManager> {
         let kv = self.ctx.get_key_value(&self.sys_locks).await?;
         Ok(LockManager { kv: Arc::new(kv) })
@@ -400,12 +434,16 @@ impl DistributedLocks {
 /// Error type for lock manager operations.
 #[derive(thiserror::Error, Debug)]
 pub enum LockManagerError {
+    /// Error creating a key-value store.
     #[error(transparent)]
     CreateKeyValue(#[from] async_nats::error::Error<CreateKeyValueErrorKind>),
+    /// Error accessing a key-value store.
     #[error(transparent)]
     KeyValue(#[from] async_nats::error::Error<KeyValueErrorKind>),
+    /// Error watching key-value store changes.
     #[error(transparent)]
     Watch(#[from] async_nats::error::Error<kv::WatchErrorKind>),
+    /// Unable to acquire lock after exhausting retries.
     #[error("unable to lock resource after {0:?}")]
     OutOfRetries(std::time::Duration),
 }
@@ -413,14 +451,19 @@ pub enum LockManagerError {
 /// Error type for sequence manager operations.
 #[derive(thiserror::Error, Debug)]
 pub enum SequenceManagerError {
+    /// Error connecting to NATS.
     #[error(transparent)]
     Connect(#[from] async_nats::error::Error<ConnectErrorKind>),
+    /// Error creating a key-value store.
     #[error(transparent)]
     CreateKeyValue(#[from] async_nats::error::Error<CreateKeyValueErrorKind>),
+    /// Error accessing a key-value store.
     #[error(transparent)]
     KeyValue(#[from] async_nats::error::Error<KeyValueErrorKind>),
+    /// Error putting a value to the key-value store.
     #[error(transparent)]
     Put(#[from] async_nats::error::Error<async_nats::jetstream::kv::PutErrorKind>),
+    /// Error reading an entry from the key-value store.
     #[error(transparent)]
     Entry(#[from] async_nats::error::Error<async_nats::jetstream::kv::EntryErrorKind>),
 }
@@ -467,6 +510,7 @@ impl SequenceManager {
         Ok(self.ctx.get_key_value(bucket).await?)
     }
 
+    /// Gets the next sequence number for the given prefix, creating the bucket if needed.
     pub async fn next(&self, prefix: &str, id: i64) -> Result<i64, SequenceManagerError> {
         let bucket = format!("sm-{prefix}");
         if !self.exists(&bucket).await? {
@@ -485,6 +529,7 @@ impl SequenceManager {
         }
     }
 
+    /// Increments the sequence number for the given prefix.
     pub async fn increment(&self, prefix: &str, id: i64) -> Result<i64, SequenceManagerError> {
         let bucket = format!("sm-{prefix}");
         let store = self.get(&bucket).await?;
@@ -503,6 +548,10 @@ pub struct LockManager {
 }
 
 impl LockManager {
+    /// Runs the given future while holding a distributed lock.
+    ///
+    /// The lock is automatically acquired before the future runs and released
+    /// when the future completes or the holder crashes.
     pub async fn run_locked<N, O, F, E>(&self, name: N, f: F) -> Result<O, E>
     where
         N: Into<String>,

--- a/crates/nats/src/subject.rs
+++ b/crates/nats/src/subject.rs
@@ -1,41 +1,66 @@
 use async_graphql::{Enum, OutputType, SimpleObject};
 use strum::{AsRefStr, EnumString};
 
+/// Operation type for events.
 #[derive(Default, Debug, EnumString, AsRefStr, Clone, Copy, PartialEq, Eq, Enum)]
 #[strum(serialize_all = "lowercase")]
 pub enum Op {
+    /// Request operation.
     #[default]
     Req,
+    /// Response operation.
     Res,
+    /// Mutation operation.
     Mut,
 }
 
+/// Event type.
 #[derive(Default, Debug, EnumString, AsRefStr, Clone, Copy, PartialEq, Eq, Enum)]
 #[strum(serialize_all = "lowercase")]
 pub enum Type {
+    /// Unknown type.
     #[default]
     Unknown,
+    /// Create event.
     Create,
+    /// Renew event.
     Renew,
+    /// Update event.
     Update,
+    /// Delete event.
     Delete,
+    /// Download event.
     Download,
+    /// Upload event.
     Upload,
+    /// Import event.
     Import,
+    /// Export event.
     Export,
+    /// Send event.
     Send,
+    /// Receive event.
     Recv,
+    /// Assign event.
     Assign,
+    /// Assign request event.
     AssignRequest,
+    /// Reassign event.
     ReAssign,
+    /// Assign update event.
     AssignUpdate,
+    /// Unassign event.
     Unassign,
+    /// Activate event.
     Activate,
+    /// Deactivate event.
     Deactivate,
 }
 
+/// Constant for no value.
 pub const NONE: &str = "_";
 
+/// Generic event structure for NATS subjects.
 #[derive(Default, Debug, Clone, SimpleObject)]
 pub struct Event<V, P, C>
 where
@@ -43,17 +68,27 @@ where
     P: Clone + OutputType,
     C: Clone + OutputType,
 {
+    /// Event version.
     pub version: V,
+    /// Operation type.
     pub op: Op,
+    /// Event type.
     pub ty: Type,
+    /// Parent context.
     pub parent_ctx: P,
+    /// Context type.
     pub ctx_type: C,
+    /// Context string.
     pub ctx: Option<String>,
+    /// Request ID.
     pub request_id: Option<String>,
+    /// Actor who triggered the event.
     pub actor: Option<String>,
+    /// Whether this is an error event.
     pub error: bool,
 }
 
+/// Format an event as a NATS subject string.
 fn format<V, P, C>(ev: &Event<V, P, C>, resource_name: impl std::fmt::Display) -> String
 where
     V: AsRef<str> + Clone + OutputType,
@@ -85,14 +120,19 @@ where
     )
 }
 
+/// Trait for types that have a resource name.
 pub trait ResourceName {
+    /// Get the resource name.
     fn name(&self) -> &str;
 }
 
+/// Trait for types with a static resource name.
 pub trait StaticResourceName {
+    /// Get the static resource name.
     fn name() -> &'static str;
 }
 
+/// A Subject with an event and extra data.
 #[derive(Debug, Clone)]
 pub struct Subject<V, P, C, E>(pub Event<V, P, C>, pub E)
 where
@@ -106,42 +146,52 @@ where
     C: OutputType + Default + AsRef<str> + Copy,
     E: OutputType + Default,
 {
+    /// Get the version.
     pub fn version(&self) -> V {
         self.0.version
     }
 
+    /// Get the operation.
     pub fn op(&self) -> Op {
         self.0.op
     }
 
+    /// Get the type.
     pub fn ty(&self) -> Type {
         self.0.ty
     }
 
+    /// Get the parent context.
     pub fn parent_ctx(&self) -> P {
         self.0.parent_ctx
     }
 
+    /// Get the context type.
     pub fn ctx_type(&self) -> C {
         self.0.ctx_type
     }
 
+    /// Get the context.
     pub fn ctx(&self) -> Option<&str> {
         self.0.ctx.as_deref()
     }
 
+    /// Get the request ID.
     pub fn request_id(&self) -> Option<&str> {
         self.0.request_id.as_deref()
     }
 
+    /// Get the actor.
     pub fn actor(&self) -> Option<&str> {
         self.0.actor.as_deref()
     }
 
+    /// Check if this is an error.
     pub fn error(&self) -> bool {
         self.0.error
     }
 
+    /// Create a factory for the given type.
     fn factory(ty: Type) -> Self {
         let ev = Event {
             ty,
@@ -150,131 +200,161 @@ where
         Self(ev, E::default())
     }
 
+    /// Create a create subject.
     pub fn create() -> Self {
         Self::factory(Type::Create)
     }
 
+    /// Create a renew subject.
     pub fn renew() -> Self {
         Self::factory(Type::Renew)
     }
 
+    /// Create an update subject.
     pub fn update() -> Self {
         Self::factory(Type::Update)
     }
 
+    /// Create a delete subject.
     pub fn delete() -> Self {
         Self::factory(Type::Delete)
     }
 
+    /// Create a download subject.
     pub fn download() -> Self {
         Self::factory(Type::Download)
     }
 
+    /// Create an upload subject.
     pub fn upload() -> Self {
         Self::factory(Type::Upload)
     }
 
+    /// Create an import subject.
     pub fn import() -> Self {
         Self::factory(Type::Import)
     }
 
+    /// Create an export subject.
     pub fn export() -> Self {
         Self::factory(Type::Export)
     }
 
+    /// Create a send subject.
     pub fn send() -> Self {
         Self::factory(Type::Send)
     }
 
+    /// Create a recv subject.
     pub fn recv() -> Self {
         Self::factory(Type::Recv)
     }
 
+    /// Create an assign subject.
     pub fn assign() -> Self {
         Self::factory(Type::Assign)
     }
 
+    /// Create an assign_request subject.
     pub fn assign_request() -> Self {
         Self::factory(Type::AssignRequest)
     }
 
+    /// Create a re_assign subject.
     pub fn re_assign() -> Self {
         Self::factory(Type::ReAssign)
     }
 
+    /// Create an assign_update subject.
     pub fn assign_update() -> Self {
         Self::factory(Type::AssignUpdate)
     }
 
+    /// Create an unassign subject.
     pub fn unassign() -> Self {
         Self::factory(Type::Unassign)
     }
 
+    /// Create an activate subject.
     pub fn activate() -> Self {
         Self::factory(Type::Activate)
     }
 
+    /// Create a deactivate subject.
     pub fn deactivate() -> Self {
         Self::factory(Type::Deactivate)
     }
 
+    /// Convert to a mutation operation.
     pub fn into_mut(mut self) -> Self {
         self.0.op = Op::Mut;
         self
     }
 
+    /// Convert to a response operation.
     pub fn into_response(mut self) -> Self {
         self.0.op = Op::Res;
         self
     }
 
+    /// Convert to a success response.
     pub fn into_success(mut self) -> Self {
         self = self.into_response();
         self.0.error = false;
         self
     }
 
+    /// Convert to an error response.
     pub fn into_error(mut self) -> Self {
         self = self.into_response();
         self.0.error = true;
         self
     }
 
+    /// Attach a resource to the subject.
+    /// Attaches a resource to the subject.
     pub fn with_resource(mut self, resource: E) -> Self {
         self.1 = resource;
         self
     }
 
+    /// Sets the event type.
     pub fn with_type(mut self, ty: Type) -> Self {
         self.0.ty = ty;
         self
     }
 
+    /// Sets the parent context.
     pub fn with_parent_ctx<T: Into<P>>(mut self, ctx: T) -> Self {
         self.0.parent_ctx = ctx.into();
         self
     }
 
+    /// Sets the context type.
     pub fn with_ctx_type(mut self, ctx_type: C) -> Self {
         self.0.ctx_type = ctx_type;
         self
     }
 
+    /// Sets the context string.
     pub fn with_ctx<S: Into<String>>(mut self, ctx: S) -> Self {
         self.0.ctx = Some(ctx.into());
         self
     }
 
+    /// Sets the request ID.
     pub fn with_request_id<S: Into<String>>(mut self, request_id: S) -> Self {
         self.0.request_id = Some(request_id.into());
         self
     }
 
+    /// Sets the actor who triggered the event.
     pub fn with_actor<S: Into<String>>(mut self, actor: S) -> Self {
         self.0.actor = Some(actor.into());
         self
     }
 
+    /// Sets the version.
     pub fn with_version(mut self, version: V) -> Self {
         self.0.version = version;
         self
@@ -288,11 +368,13 @@ where
     C: Clone + OutputType + std::fmt::Debug + AsRef<str>,
     E: std::fmt::Debug + ResourceName,
 {
+    /// Returns the NATS subject for this event.
     pub fn resource(&self) -> async_nats::Subject {
         format(&self.0, self.1.name()).into()
     }
 }
 
+/// Marker type for Resource.
 pub struct Resource;
 use crate::EventToSubject;
 


### PR DESCRIPTION
## Summary
- Add module-level documentation with features, quick start, and environment variables
- Document `Config`, `Nats`, `Publisher` structs
- Document `DistributedLocks`, `LockManager`, `SequenceManager` 
- Document `Lock`, `LockState` types and `EventToSubject` trait

Closes #96