### PR TITLE
Document qm-role-build crate (issue #98)

### DIFF
--- a/crates/role-build/src/lib.rs
+++ b/crates/role-build/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 //! Role builder from markdown tables.
 //!
 //! This crate provides utilities to generate Rust code for role-based access control (RBAC)


### PR DESCRIPTION
## Summary
- Add module-level documentation with input format, usage, and examples
- Document `generate()` and `generate_to_writer()` functions

Closes #98