### PR TITLE
Document qm-redis crate (issue #145)

### DIFF
--- a/crates/redis/src/config.rs
+++ b/crates/redis/src/config.rs
@@ -1,6 +1,9 @@
+#![deny(missing_docs)]
+
 use serde::Deserialize;
 use std::sync::Arc;
 
+/// Redis configuration.
 #[derive(Deserialize)]
 pub struct Config {
     host: Option<Arc<str>>,
@@ -10,30 +13,36 @@ pub struct Config {
 }
 
 impl Config {
+    /// Creates a new Config from environment variables with default REDIS_ prefix.
     pub fn new() -> envy::Result<Self> {
         ConfigBuilder::default().build()
     }
 
+    /// Creates a new ConfigBuilder for custom configuration.
     pub fn builder<'a>() -> ConfigBuilder<'a> {
         ConfigBuilder::default()
     }
 
+    /// Returns the Redis connection address.
     pub fn address(&self) -> &str {
         self.address.as_deref().unwrap()
     }
 }
 
+/// Builder for creating Config with custom settings.
 #[derive(Default)]
 pub struct ConfigBuilder<'a> {
     prefix: Option<&'a str>,
 }
 
 impl<'a> ConfigBuilder<'a> {
+    /// Sets a custom environment variable prefix.
     pub fn with_prefix(mut self, prefix: &'a str) -> Self {
         self.prefix = Some(prefix);
         self
     }
 
+    /// Builds the Config from environment variables.
     pub fn build(self) -> envy::Result<Config> {
         let mut cfg: Config = if let Some(prefix) = self.prefix {
             envy::prefixed(prefix)

--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 //! Redis connection, caching, and work queue utilities.
 //!
 //! This crate provides Redis connection management with connection pooling,
@@ -42,7 +44,9 @@ use redis::RedisError;
 use redis::ToRedisArgs;
 use std::sync::Arc;
 mod config;
+/// Distributed locking utilities.
 pub mod lock;
+/// Work queue implementation.
 pub mod work_queue;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -68,10 +72,13 @@ use crate::lock::Lock;
 /// Error type for cache operations.
 #[derive(Debug, thiserror::Error)]
 pub enum CacheError {
+    /// Connection pool error.
     #[error(transparent)]
     Pool(#[from] PoolError),
+    /// Redis error.
     #[error(transparent)]
     Redis(#[from] RedisError),
+    /// Fetch operation failed.
     #[error("failed to fetch: {0}")]
     Failure(String),
 }
@@ -111,6 +118,7 @@ where
     }
 }
 
+/// Internal state for Redis connection.
 pub struct Inner {
     config: RedisConfig,
     client: redis::Client,
@@ -130,6 +138,7 @@ impl AsRef<deadpool_redis::Pool> for Redis {
 }
 
 impl Redis {
+    /// Creates a new Redis connection from environment variables.
     pub fn new() -> anyhow::Result<Self> {
         let config = RedisConfig::builder().build()?;
         let client = redis::Client::open(config.address())?;
@@ -144,28 +153,34 @@ impl Redis {
         })
     }
 
+    /// Returns a reference to the Redis configuration.
     pub fn config(&self) -> &RedisConfig {
         &self.inner.config
     }
 
+    /// Returns a reference to the Redis client.
     pub fn client(&self) -> &redis::Client {
         &self.inner.client
     }
 
+    /// Returns a clone of the connection pool.
     pub fn pool(&self) -> Arc<deadpool_redis::Pool> {
         Arc::new(self.inner.pool.clone())
     }
 
+    /// Acquires a connection from the pool.
     pub async fn connect(&self) -> Result<deadpool_redis::Connection, deadpool_redis::PoolError> {
         self.inner.pool.get().await
     }
 
+    /// Clears all data from the Redis database.
     pub async fn cleanup(&self) -> anyhow::Result<()> {
         let mut con = self.connect().await?;
         let _: redis::Value = redis::cmd("FLUSHALL").query_async(&mut con).await?;
         Ok(())
     }
 
+    /// Acquires a distributed lock with the given parameters.
     pub async fn lock(
         &self,
         key: &str,
@@ -177,6 +192,7 @@ impl Redis {
         lock::lock(&mut con, key, ttl, retry_count, retry_delay).await
     }
 
+    /// Releases a distributed lock.
     pub async fn unlock(&self, key: &str, lock_id: &str) -> Result<i64, lock::Error> {
         let mut con = self.connect().await?;
         lock::unlock(&mut con, key, lock_id).await
@@ -206,6 +222,7 @@ where
     result
 }
 
+/// Macro to implement AsRef<Redis> for a storage type.
 #[macro_export]
 macro_rules! redis {
     ($storage:ty) => {
@@ -217,19 +234,26 @@ macro_rules! redis {
     };
 }
 
+/// Type for running worker futures.
 pub type RunningWorkers =
     FuturesUnordered<Pin<Box<dyn Future<Output = String> + Send + Sync + 'static>>>;
 
+/// Type for executable item futures.
 pub type ExecItemFuture = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'static>>;
 
+/// Context passed to worker functions.
 pub struct WorkerContext<Ctx>
 where
     Ctx: Clone + Send + Sync + 'static,
 {
     ctx: Ctx,
+    /// The worker ID.
     pub worker_id: usize,
+    /// The work queue.
     pub queue: Arc<WorkQueue>,
+    /// The Redis client.
     pub client: Arc<redis::Client>,
+    /// The current work item.
     pub item: Item,
 }
 
@@ -237,9 +261,12 @@ impl<Ctx> WorkerContext<Ctx>
 where
     Ctx: Clone + Send + Sync + 'static,
 {
+    /// Returns a reference to the context.
     pub fn ctx(&self) -> &Ctx {
         &self.ctx
     }
+
+    /// Marks the current item as completed.
     pub async fn complete(&self) -> anyhow::Result<()> {
         let mut con = self.client.get_multiplexed_async_connection().await?;
         self.queue.complete(&mut con, &self.item).await?;
@@ -258,12 +285,14 @@ async fn add(
     instances.write().await.as_mut().unwrap().push(fut);
 }
 
+/// Trait for implementing worker logic.
 #[async_trait::async_trait]
 pub trait Work<Ctx, T>: Send + Sync
 where
     Ctx: Clone + Send + Sync + 'static,
     T: DeserializeOwned + Send + Sync,
 {
+    /// Runs the worker logic for a given item.
     async fn run(&self, ctx: WorkerContext<Ctx>, item: T) -> anyhow::Result<()>;
 }
 
@@ -365,11 +394,13 @@ pub struct Workers {
 }
 
 impl Workers {
+    /// Creates a new Workers instance from a Redis config.
     pub fn new(config: &RedisConfig) -> RedisResult<Self> {
         let client = Arc::new(redis::Client::open(config.address())?);
         Ok(Self::new_with_client(client))
     }
 
+    /// Creates a new Workers instance with an existing Redis client.
     pub fn new_with_client(client: Arc<redis::Client>) -> Self {
         Self {
             inner: Arc::new(WorkerInner {
@@ -380,6 +411,7 @@ impl Workers {
         }
     }
 
+    /// Starts the workers with the given context and async worker.
     pub async fn start<Ctx, T>(&self, ctx: Ctx, worker: AsyncWorker<Ctx, T>) -> anyhow::Result<()>
     where
         Ctx: Clone + Send + Sync + 'static,
@@ -460,6 +492,7 @@ impl Workers {
         Ok(())
     }
 
+    /// Terminates all workers gracefully.
     pub async fn terminate(&self) -> anyhow::Result<()> {
         if !self.inner.is_running.load(Ordering::SeqCst) {
             anyhow::bail!("Workers already terminated");
@@ -482,6 +515,7 @@ pub struct Producer {
 }
 
 impl Producer {
+    /// Creates a new Producer from a Redis config and prefix.
     pub fn new<S>(config: &RedisConfig, prefix: S) -> anyhow::Result<Self>
     where
         S: Into<String>,
@@ -491,6 +525,7 @@ impl Producer {
         Ok(Self::new_with_client(redis, prefix))
     }
 
+    /// Creates a new Producer with an existing connection pool and prefix.
     pub fn new_with_client<S>(client: Arc<deadpool_redis::Pool>, prefix: S) -> Self
     where
         S: Into<String>,
@@ -499,6 +534,7 @@ impl Producer {
         Self { client, queue }
     }
 
+    /// Adds an item using an existing connection.
     pub async fn add_item_with_connection<C, T>(&self, db: &mut C, data: &T) -> anyhow::Result<()>
     where
         C: AsyncCommands,
@@ -509,6 +545,7 @@ impl Producer {
         Ok(())
     }
 
+    /// Adds an item to the queue.
     pub async fn add_item<T>(&self, data: &T) -> anyhow::Result<()>
     where
         T: Serialize,
@@ -543,6 +580,7 @@ where
     Ctx: Clone + Send + Sync + 'static,
     T: DeserializeOwned + Send + Sync,
 {
+    /// Creates a new AsyncWorker with the given prefix.
     pub fn new<S>(prefix: S) -> Self
     where
         S: Into<String>,
@@ -560,21 +598,25 @@ where
         }
     }
 
+    /// Sets the timeout for worker tasks.
     pub fn with_timeout(mut self, timeout: u64) -> Self {
         self.timeout = timeout;
         self
     }
 
+    /// Sets the lease duration for queue items.
     pub fn with_lease_duration(mut self, lease_duration: u64) -> Self {
         self.lease_duration = lease_duration;
         self
     }
 
+    /// Sets the number of worker threads.
     pub fn with_num_workers(mut self, num_workers: usize) -> Self {
         self.num_workers = num_workers;
         self
     }
 
+    /// Creates a Producer for adding items to the queue.
     pub fn producer(&self, client: Arc<deadpool_redis::Pool>) -> Producer {
         Producer {
             client,
@@ -582,6 +624,7 @@ where
         }
     }
 
+    /// Recovers pending items from a previous run.
     pub async fn recover<C: AsyncCommands>(&self, db: &mut C) -> anyhow::Result<()> {
         let l = lock::lock(db, &self.recovery_key, 3600, 36, 100).await?;
         self.recovery_queue.recover(db).await?;
@@ -589,6 +632,7 @@ where
         Ok(())
     }
 
+    /// Sets the work function and returns self.
     pub fn run(mut self, work: impl Work<Ctx, T> + 'static) -> Self {
         self.work = Some(Box::new(work));
         self

--- a/crates/redis/src/lock.rs
+++ b/crates/redis/src/lock.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use redis::AsyncCommands;
 use redis::RedisError;
 use redis::SetOptions;
@@ -5,24 +7,40 @@ use redis::Value as RedisValue;
 use tokio::time::{sleep, Duration};
 use uuid::Uuid;
 
+/// Error reasons for lock acquisition.
 pub mod error {
+    /// Reasons why a lock cannot be acquired.
     #[derive(thiserror::Error, Clone, Debug, PartialEq)]
     pub enum CanNotGetLockReason {
+        /// Lock is currently held by another process.
         #[error("lock is busy")]
         LockIsBussy,
+        /// Lock is still busy after exhausting retries.
         #[error("lock is still busy with count: {retry_count} and delay {retry_delay}")]
-        LockIsStillBusy { retry_count: u32, retry_delay: u32 },
+        LockIsStillBusy {
+            /// Number of retry attempts made.
+            retry_count: u32,
+            /// Delay between retries in milliseconds.
+            retry_delay: u32
+        },
     }
 }
 
+/// Error type for lock operations.
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
+    /// Connection pool error.
     #[error("pool error {0}")]
     PoolError(String),
+    /// Redis error.
     #[error("redis error {0}")]
     RedisError(String),
+    /// Could not acquire lock.
     #[error("{0}")]
-    CanNotGetLock(error::CanNotGetLockReason),
+    CanNotGetLock(
+        /// The reason why the lock could not be acquired.
+        error::CanNotGetLockReason,
+    ),
 }
 
 impl From<RedisError> for Error {
@@ -45,11 +63,14 @@ const UNLOCK_SCRIPT: &str = r#"
   end
 "#;
 
+/// A distributed lock handle.
 #[derive(Debug)]
 pub struct Lock {
+    /// Unique ID of the lock.
     pub id: String,
 }
 
+/// Attempts to acquire a lock without retries.
 pub async fn try_lock<C: AsyncCommands, T: AsRef<str>>(
     db: &mut C,
     key: T,
@@ -60,12 +81,6 @@ pub async fn try_lock<C: AsyncCommands, T: AsRef<str>>(
         .with_expiration(redis::SetExpiry::PX(ttl as u64))
         .conditional_set(redis::ExistenceCheck::NX);
     let result = db.set_options(key.as_ref(), &id, options).await?;
-    // let result = redis::Script::new(LOCK_SCRIPT)
-    //     .arg(key.as_ref())
-    //     .arg(&id)
-    //     .arg(ttl)
-    //     .invoke_async(db)
-    //     .await?;
 
     match result {
         RedisValue::Okay => Ok(Lock { id }),
@@ -75,6 +90,7 @@ pub async fn try_lock<C: AsyncCommands, T: AsRef<str>>(
     }
 }
 
+/// Acquires a distributed lock with retries.
 pub async fn lock<C: AsyncCommands, T>(
     db: &mut C,
     key: T,
@@ -106,6 +122,7 @@ where
     ))
 }
 
+/// Releases a distributed lock.
 pub async fn unlock<C: AsyncCommands, K, V>(db: &mut C, key: K, lock_id: V) -> Result<i64, Error>
 where
     K: AsRef<str>,

--- a/crates/redis/src/work_queue.rs
+++ b/crates/redis/src/work_queue.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use std::future::Future;
 use std::time::Duration;
 
@@ -5,16 +7,19 @@ use deadpool_redis::redis::{self, AsyncCommands, RedisResult, Value};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Key prefix for work queue keys.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct KeyPrefix {
     prefix: String,
 }
 
 impl KeyPrefix {
+    /// Creates a new KeyPrefix.
     pub fn new(prefix: String) -> KeyPrefix {
         KeyPrefix { prefix }
     }
 
+    /// Returns the full key with the given name appended.
     pub fn of(&self, name: &str) -> String {
         let mut key = String::with_capacity(self.prefix.len() + name.len());
         key.push_str(&self.prefix);
@@ -22,10 +27,12 @@ impl KeyPrefix {
         key
     }
 
+    /// Creates a new KeyPrefix by appending the given name.
     pub fn and(&self, other: &str) -> KeyPrefix {
         KeyPrefix::new(self.of(other))
     }
 
+    /// Appends a string to this prefix.
     pub fn concat(mut self, other: &str) -> KeyPrefix {
         self.prefix.push_str(other);
         self
@@ -56,13 +63,17 @@ impl AsRef<str> for KeyPrefix {
     }
 }
 
+/// A work item in the queue.
 #[derive(Clone, Debug)]
 pub struct Item {
+    /// Unique ID of the item.
     pub id: String,
+    /// Binary data of the item.
     pub data: Box<[u8]>,
 }
 
 impl Item {
+    /// Creates a new Item with the given data.
     pub fn new(data: Box<[u8]>) -> Item {
         Item {
             data,
@@ -70,23 +81,28 @@ impl Item {
         }
     }
 
+    /// Creates a new Item from string data.
     pub fn from_string_data(data: String) -> Item {
         Item::new(data.into_bytes().into_boxed_slice())
     }
 
+    /// Creates a new Item from JSON-serializable data.
     pub fn from_json_data<T: Serialize>(data: &T) -> serde_json::Result<Item> {
         Ok(Item::new(serde_json::to_vec(data)?.into()))
     }
 
+    /// Deserializes the item data as JSON.
     pub fn data_json<'a, T: Deserialize<'a>>(&'a self) -> serde_json::Result<T> {
         serde_json::from_slice(&self.data)
     }
 
+    /// Deserializes the item data as JSON with static lifetime.
     pub fn data_json_static<T: for<'de> Deserialize<'de>>(&self) -> serde_json::Result<T> {
         serde_json::from_slice(&self.data)
     }
 }
 
+/// Work queue for managing async jobs.
 pub struct WorkQueue {
     session: String,
     main_queue_key: String,
@@ -96,6 +112,7 @@ pub struct WorkQueue {
 }
 
 impl WorkQueue {
+    /// Creates a new WorkQueue with the given name.
     pub fn new(name: KeyPrefix) -> WorkQueue {
         WorkQueue {
             session: Uuid::new_v4().to_string(),
@@ -106,6 +123,7 @@ impl WorkQueue {
         }
     }
 
+    /// Recovers items from a previous run.
     pub async fn recover<C: AsyncCommands>(&self, db: &mut C) -> RedisResult<()> {
         let processing: RedisResult<Value> = db.lrange(&self.processing_key, 0, -1).await;
         let mut pipeline = Box::new(redis::pipe());
@@ -124,17 +142,20 @@ impl WorkQueue {
         pipeline.query_async(db).await
     }
 
+    /// Adds an item to a pipeline.
     pub fn add_item_to_pipeline(&self, pipeline: &mut redis::Pipeline, item: &Item) {
         pipeline.set(self.item_data_key.of(&item.id), item.data.as_ref());
         pipeline.lpush(&self.main_queue_key, &item.id);
     }
 
+    /// Adds an item to the queue.
     pub async fn add_item<C: AsyncCommands>(&self, db: &mut C, item: &Item) -> RedisResult<()> {
         let mut pipeline = Box::new(redis::pipe());
         self.add_item_to_pipeline(&mut pipeline, item);
         pipeline.query_async(db).await
     }
 
+    /// Returns the length of the queue.
     pub fn queue_len<'a, C: AsyncCommands>(
         &'a self,
         db: &'a mut C,
@@ -142,6 +163,7 @@ impl WorkQueue {
         db.llen(&self.main_queue_key)
     }
 
+    /// Returns the number of items being processed.
     pub fn processing<'a, C: AsyncCommands>(
         &'a self,
         db: &'a mut C,
@@ -149,6 +171,7 @@ impl WorkQueue {
         db.llen(&self.processing_key)
     }
 
+    /// Leases an item from the queue.
     pub async fn lease<C: AsyncCommands>(
         &self,
         db: &mut C,
@@ -199,6 +222,7 @@ impl WorkQueue {
         Ok(Some(item))
     }
 
+    /// Marks an item as completed and removes it from the queue.
     pub async fn complete<C: AsyncCommands>(&self, db: &mut C, item: &Item) -> RedisResult<bool> {
         let removed: usize = db.lrem(&self.processing_key, 0, &item.id).await?;
         if removed == 0 {


### PR DESCRIPTION
## Summary
- Add module-level documentation with features, usage, and environment variables
- Document `Redis`, `Workers`, `Producer`, `AsyncWorker` structs
- Document `CacheError`, `Json` types and `mutex_run` function

Closes #145