### PR TITLE
173 keycloak add some authentication required action apis

### DIFF
--- a/crates/keycloak/src/client.rs
+++ b/crates/keycloak/src/client.rs
@@ -480,7 +480,7 @@ impl Keycloak {
             .roles_with_role_name_users_get(role_name)
             .await?
             .into_iter()
-            .nth(0))
+            .next())
     }
 
     /// Gets a user by username.
@@ -499,7 +499,7 @@ impl Keycloak {
             .username(username)
             .await?
             .into_iter()
-            .nth(0))
+            .next())
     }
 
     /// Gets realm information.


### PR DESCRIPTION
As mentioned in the issue, this MR adds functions for 3 Keycloak endpoints.

I've also refactored the other functions to be more consistent in how a request result is mapped.

I've also removed the `tracing::error` calls, because the `qm` crate shouldn't force log errors in those API call functions, they already return the error, so the user of the crate is responsible for handling the error and should also be able to decide if the error is logged, or not.