### PR TITLE
Make sure we don't end up with a double slash at the end of the url

### DIFF
--- a/crates/keycloak/src/realm.rs
+++ b/crates/keycloak/src/realm.rs
@@ -43,7 +43,10 @@ where
     }) {
         client.redirect_uris = Some(
             urls.iter()
-                .map(|uri| [format!("{}*", uri), uri.to_string()])
+                .map(|uri| {
+                    let uri = format!("{}/", uri.trim_end_matches("/"));
+                    [format!("{}*", &uri), uri]
+                })
                 .flatten()
                 .collect(),
         );

--- a/crates/keycloak/src/realm.rs
+++ b/crates/keycloak/src/realm.rs
@@ -47,8 +47,8 @@ where
                 .flatten()
                 .collect(),
         );
-        client.base_url = Some(format!("{}/", base_url));
-        client.root_url = Some(format!("{}/", base_url));
+        client.base_url = Some(format!("{}/", base_url.trim_end_matches("/")));
+        client.root_url = Some(format!("{}/", base_url.trim_end_matches("/")));
         client.direct_access_grants_enabled = Some(true);
     }
     let ctx = ValidationContext {

--- a/crates/keycloak/src/validation/validator.rs
+++ b/crates/keycloak/src/validation/validator.rs
@@ -359,7 +359,10 @@ async fn check_client(
         if let Some(urls) = &client.redirect_uris {
             if !urls.iter().all(|url| {
                 ctx.cfg().public_urls().contains(&&**url)
-                    || ctx.cfg().public_urls().contains(&&*url.replace('*', ""))
+                    || ctx
+                        .cfg()
+                        .public_urls()
+                        .contains(&&*url.trim_end_matches(['*', '/']))
             }) {
                 tracing::info!(
                     "[{}]: Expected the 'redirect_uris' values '{:?}' to match matches '{:?}'",


### PR DESCRIPTION
We could end up with double dashes in the `Root URL` and `Home URL`