### PR TITLE
Switch from Inflector to heck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,10 +7,6 @@ name = "Inflector"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
 
 [[package]]
 name = "ahash"
@@ -3099,7 +3095,6 @@ dependencies = [
 name = "qm-entity-derive"
 version = "0.0.79"
 dependencies = [
- "Inflector",
  "darling 0.21.3",
  "lazy_static",
  "proc-macro-crate",
@@ -3302,8 +3297,8 @@ dependencies = [
 name = "qm-role-build"
 version = "0.0.79"
 dependencies = [
- "Inflector",
  "anyhow",
+ "heck 0.5.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ time = { version = "0.3.47", features = [
     "macros",
     "serde",
 ] }
-Inflector = "0.11.4"
+heck = "0.5.0"
 async-graphql = { version = "7.2.1", features = [
     "bson",
     "chrono",

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -14,7 +14,6 @@ repository = "https://github.com/hd-gmbh-dev/quick-microservice-rs"
 proc-macro = true
 
 [dependencies]
-Inflector = "0.11.4"
 darling = "0.21.3"
 proc-macro-crate = "3.1.0"
 proc-macro2 = "1.0.24"

--- a/crates/role-build/Cargo.toml
+++ b/crates/role-build/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/hd-gmbh-dev/quick-microservice-rs"
 
 [dependencies]
 anyhow.workspace = true
-Inflector.workspace = true
+heck.workspace = true

--- a/crates/role-build/src/writer.rs
+++ b/crates/role-build/src/writer.rs
@@ -3,6 +3,8 @@ use std::{
     path::Path,
 };
 
+use heck::{ToPascalCase, ToShoutySnakeCase, ToSnakeCase};
+
 use crate::parser::ParseResult;
 
 pub struct WriteResult<W> {
@@ -85,7 +87,7 @@ where
                 1,
                 &format!(
                     "{},",
-                    inflector::cases::classcase::to_class_case(permission.as_ref())
+                    permission.as_ref().to_pascal_case()
                 ),
             )?;
         }
@@ -104,7 +106,7 @@ where
                 1,
                 &format!(
                     "{},",
-                    inflector::cases::classcase::to_class_case(resource.as_ref())
+                    resource.as_ref().to_pascal_case()
                 ),
             )?;
         }
@@ -118,9 +120,7 @@ where
                 user_group_name_mappings.get(&role_mapping.user_group)
             {
                 group_names.insert(user_group_name);
-                let cnst_name = inflector::cases::screamingsnakecase::to_screaming_snake_case(
-                    role_mapping.user_group.as_ref(),
-                );
+                let cnst_name = role_mapping.user_group.as_ref().to_shouty_snake_case();
                 self.write_line(
                     0,
                     &format!(
@@ -129,7 +129,7 @@ where
                     ),
                 )?;
                 let fn_name =
-                    inflector::cases::snakecase::to_snake_case(role_mapping.user_group.as_ref());
+                    role_mapping.user_group.as_ref().to_snake_case();
                 self.write_line(
                     0,
                     &format!(
@@ -147,11 +147,11 @@ where
                 )?;
                 for role in role_mapping.roles.iter() {
                     if let Some((resource, permission)) = role.as_ref().split_once(':') {
-                        let resource = inflector::cases::classcase::to_class_case(resource);
-                        let permission = inflector::cases::classcase::to_class_case(permission);
+                        let resource = resource.to_pascal_case();
+                        let permission = permission.to_pascal_case();
                         self.write_line(2, &format!("qm::role::Role::new(Resource::{resource}, Some(Permission::{permission})),"))?;
                     } else {
-                        let resource = inflector::cases::classcase::to_class_case(role);
+                        let resource = role.to_pascal_case();
                         self.write_line(
                             2,
                             &format!("qm::role::Role::new(Resource::{resource}, None),"),
@@ -197,7 +197,7 @@ where
         )?;
         for group_name in group_names.iter() {
             let n =
-                inflector::cases::screamingsnakecase::to_screaming_snake_case(group_name.as_ref());
+                group_name.as_ref().to_shouty_snake_case();
             self.write_line(1, &format!("{n}_PATH,"))?;
         }
         self.write_line(0, "];")?;
@@ -209,14 +209,14 @@ where
                 1,
                 &format!(
                     "#[strum(serialize = \"/app/{}\")]",
-                    inflector::cases::snakecase::to_snake_case(group_name.as_ref())
+                    group_name.as_ref().to_snake_case()
                 ),
             )?;
             self.write_line(
                 1,
                 &format!(
                     "{},",
-                    inflector::cases::classcase::to_class_case(group_name.as_ref())
+                    group_name.as_ref().to_pascal_case()
                 ),
             )?;
         }
@@ -229,7 +229,7 @@ where
         self.write_line(1, "fn from(val: BuiltInGroup) -> Self {")?;
         self.write_line(2, "match val {")?;
         for r in role_mappings.iter() {
-            let fn_name = inflector::cases::snakecase::to_snake_case(r.user_group.as_ref());
+            let fn_name = r.user_group.as_ref().to_snake_case();
             self.write_line(
                 3,
                 &format!("BuiltInGroup::{} => {fn_name}_group(),", r.user_group),


### PR DESCRIPTION
Resolves #125

Replaces the `Inflector` crate with `heck` across the workspace:

- **`heck` has zero dependencies** (vs Inflector pulling in `lazy_static` + `regex`)
- **5× more downloads** and more actively maintained
- Smaller compile footprint

### Changes

- `Cargo.toml`: Replaced workspace dependency `Inflector = "0.11.4"` with `heck = "0.5.0"`
- `crates/entity-derive/Cargo.toml`: Removed unused Inflector dependency (was not referenced in source)
- `crates/role-build/Cargo.toml`: Switched to `heck.workspace = true`
- `crates/role-build/src/writer.rs`: Replaced all Inflector API calls with heck equivalents:
  - `inflector::cases::classcase::to_class_case(s)` → `s.to_pascal_case()`
  - `inflector::cases::screamingsnakecase::to_screaming_snake_case(s)` → `s.to_shouty_snake_case()`
  - `inflector::cases::snakecase::to_snake_case(s)` → `s.to_snake_case()`

### Verification

- `cargo check -p qm-role-build` ✓
- `cargo check -p qm-entity-derive` ✓
- `cargo test -p qm-role-build` ✓ (3 tests pass)
- `cargo clippy -p qm-role-build` ✓ (no warnings)