### PR TITLE
nats: add Warning event type (subject Type enum)

### DIFF
--- a/crates/nats/src/subject.rs
+++ b/crates/nats/src/subject.rs
@@ -29,6 +29,8 @@ pub enum Type {
     Update,
     /// Delete event.
     Delete,
+    /// Warning event, e.g. an upcoming automatic deletion.
+    Warning,
     /// Download event.
     Download,
     /// Upload event.
@@ -69,6 +71,14 @@ where
     C: Clone + OutputType,
 {
     /// Event version.
+    ///
+    /// Versions like `V1`/`V2` are **message** versions, not API versions.
+    /// They allow producers to evolve the subject grammar and payload formats
+    /// while already deployed consumers keep working: old consumers subscribe
+    /// to the version they understand, and producers keep publishing the
+    /// versions that are still consumed. During a migration a consumer may
+    /// therefore subscribe to several versions at once (e.g. `ev.V1.*` and
+    /// `ev.V2.*`) and must be able to parse each subscribed version.
     pub version: V,
     /// Operation type.
     pub op: Op,
@@ -218,6 +228,11 @@ where
     /// Create a delete subject.
     pub fn delete() -> Self {
         Self::factory(Type::Delete)
+    }
+
+    /// Create a warning subject.
+    pub fn warning() -> Self {
+        Self::factory(Type::Warning)
     }
 
     /// Create a download subject.
@@ -493,6 +508,23 @@ mod tests {
         assert_eq!(
             subject.resource(),
             async_nats::Subject::from_static("ev.V1.res.DE.system._.user.create._._.error"),
+        );
+    }
+
+    #[test]
+    fn test_subject_warning() {
+        let subject = Subject::<Version, ParentCtx, CtxType, Resource>::warning()
+            .with_parent_ctx(ParentCtx::BY)
+            .with_ctx_type(CtxType::Test)
+            .with_ctx("R3425921760D")
+            .with_request_id("165789548978")
+            .with_actor("EA4DCDCA-1CFD-48B9-905A-60DAB47964CB")
+            .with_resource(Resource::Qr);
+        assert_eq!(
+            subject.resource(),
+            async_nats::Subject::from_static(
+                "ev.V1.req.BY.test.R3425921760D.qr.warning.165789548978.EA4DCDCA-1CFD-48B9-905A-60DAB47964CB",
+            ),
         );
     }
 


### PR DESCRIPTION
## Summary
Adds a `Warning` event type to the `qm-nats` subject `Type` enum, plus a `Subject::warning()` factory, a unit test, and documentation of the subject versioning design.

Closes #191

## Why
A consuming system needs to email users about an upcoming automatic deletion of a document (e.g. 10 days before deletion). Deletion is already emitted as `Type::Delete`; this new `Warning` type lets consumers distinguish *"about to be deleted"* (send reminder) from *"deleted"* (cleanup) — subject e.g.:

```
ev.V2.mut.<parent>.<ctx_type>.<ctx>.<resource>.warning.<process_id>.<actor>
```

## Changes
- `crates/nats/src/subject.rs`: add `Warning` variant (strum `lowercase` → `warning`), `Subject::warning()` factory, `subjects::tests::test_subject_warning`.
- Document the `Event.version` field: versions are **message versions** for backward compatibility — old consumers keep working while producers evolve; new consumers may subscribe to several versions during a migration.

## Checks
- `cargo fmt` clean
- `cargo clippy -p qm-nats --all-targets` clean
- `cargo test -p qm-nats subject` — 3 passed (incl. new warning test)

## Notes for maintainer
Additive change only — no breaking change. After merge, a patch release (v0.0.81) is needed so downstream projects can switch from rev-pins to the released version.
